### PR TITLE
Allow an 'average map size' of 100

### DIFF
--- a/src/zfarm.pug
+++ b/src/zfarm.pug
@@ -59,7 +59,7 @@ block content
           input#cd(type='text' value='400' pattern='\\d{3,}')
           | Crit damage%
         label(title='Average size of the maps you create')
-          input#size(type='text' value='27' pattern='\\d\\d')
+          input#size(type='text' value='27' pattern='\\d\\d|100')
           | Map size
         label(title='Average difficulty of the maps you create')
           input#difficulty(type='text' value='80' pattern='[1-9][0-9]*')


### PR DESCRIPTION
Even though the biome information will be incorrect, this can be used to get a sense of whether or not the player is ready to take on a unique map.